### PR TITLE
[chore] seperate template.yaml for spring supportive and vanilla VScode

### DIFF
--- a/vscode/templates/dockerfile
+++ b/vscode/templates/dockerfile
@@ -1,0 +1,20 @@
+FROM codercom/code-server
+
+RUN sudo apt update && \
+    sudo apt install -y wget build-essential &&  sudo apt install unzip zip
+
+# install JDK & MAVEN
+RUN sudo apt install -y default-jdk
+RUN sudo apt-get install -y maven
+
+# install SDKMAN
+RUN curl -s https://get.sdkman.io | bash
+RUN /bin/bash -c "source /home/coder/.sdkman/bin/sdkman-init.sh; sdk version; sdk install springboot; sdk install gradle; gradle"
+
+
+# install extenions
+RUN code-server --install-extension vscjava.vscode-java-pack &&\
+    code-server --install-extension pivotal.vscode-boot-dev-pack
+
+
+CMD ["code-server", "--auth", "none", "--bind-addr", "0.0.0.0:8080", "."]

--- a/vscode/templates/springVscodeTemplate.yaml
+++ b/vscode/templates/springVscodeTemplate.yaml
@@ -1,0 +1,112 @@
+apiVersion: tmax.io/v1
+kind: ClusterTemplate
+metadata:
+  name: vscode-template
+shortDescription: VS Code Deployment
+longDescription: Visual Studio Code Deployment
+urlDescription: https://code.visualstudio.com/
+imageUrl: https://f1.codingworldnews.com/2019/05/66b3i9a88q.png
+provider: tmax
+categories:
+- vscode
+- ide
+parameters:
+  - name: APP_NAME
+    displayName: AppName
+    description: A VS Code Deployment Name
+    required: true
+  - name: STORAGE
+    displayName: Storage
+    description: Storage size
+    required: true
+  - name: STORAGE_CLASS
+    displayName: StorageClass
+    description: Storage class
+    value: csi-cephfs-sc
+    required: true
+  - name: SERVICE_TYPE
+    displayName: ServiceType
+    description: Service Type (ClusterIP/NodePort/LoadBalancer)
+    required: true
+objects:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: ${APP_NAME}-service
+    labels:
+      app: ${APP_NAME}
+  spec:
+    type: ${SERVICE_TYPE}
+    ports:
+    - name: http
+      port: 8080
+    selector:
+      app: ${APP_NAME}
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: ${APP_NAME}-pvc
+    labels:
+      app: ${APP_NAME}
+  spec:
+    storageClassName: ${STORAGE_CLASS}
+    accessModes:
+    - ReadWriteMany
+    resources:
+      requests:
+        storage: ${STORAGE}
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: ${APP_NAME}
+    labels:
+      app: ${APP_NAME}
+  spec:
+    selector:
+      matchLabels:
+        app: ${APP_NAME}
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          app: ${APP_NAME}
+      spec:
+        containers:
+        - name: ${APP_NAME}
+          image: docker.io/tmaxcloudck/codeserver:0.2.1
+          ports:
+          - name: http
+            containerPort: 8080
+          volumeMounts:
+          - name: ${APP_NAME}-pv
+            mountPath: /home/coder/project
+            subPath: project
+          - name: ${APP_NAME}-pv
+            mountPath: /home/coder/.config/code-server
+            subPath: config
+          - name: ${APP_NAME}-pv
+            mountPath: /home/coder/.local/share/code-server
+            subPath: user-data-dir
+        volumes:
+        - name: ${APP_NAME}-pv
+          persistentVolumeClaim:
+            claimName: ${APP_NAME}-pvc
+plans:
+- name: vscode-plan1
+  description: VSCode Plan
+  metadata:
+    bullets:
+    - VSCode Deployment Plan
+    costs:
+      amount: 100
+      unit: $
+  free: false
+  bindable: true
+  plan_updateable: false
+  schemas:
+    service_instance:
+      create:
+        parameters:
+          APP_NAME: vscode-deploy
+          STORAGE: 10Gi

--- a/vscode/templates/vanillaVscodeTemplate.yaml
+++ b/vscode/templates/vanillaVscodeTemplate.yaml
@@ -74,7 +74,7 @@ objects:
       spec:
         containers:
         - name: ${APP_NAME}
-          image: docker.io/tmaxcloudck/codeserver:0.2
+          image: docker.io/codercom/code-server:3.12.0
           ports:
           - name: http
             containerPort: 8080


### PR DESCRIPTION
Split template.yaml into two part
- springVscodeTemplate.yaml (spring & java supportive)
- vanillaVscodeTemplate.yaml 

Add dockerfile for springVScodeServer
- install java, spring and related VS extensions
- disable authentication 




